### PR TITLE
fix: set as pushed only when message push is successful

### DIFF
--- a/ctrl/ctrl.go
+++ b/ctrl/ctrl.go
@@ -244,12 +244,10 @@ func (w *WatchVulnApp) pushVuln(vul *grab.VulnInfo) error {
 	var pushErr *multierror.Error
 
 	if err := w.textPusher.PushMarkdown(vul.Title, push.RenderVulnInfo(vul)); err != nil {
-		w.log.Errorf("text-pusher send markdown msg error, %s", err)
 		pushErr = multierror.Append(pushErr, err)
 	}
 
 	if err := w.rawPusher.PushRaw(push.NewRawVulnInfoMessage(vul)); err != nil {
-		w.log.Errorf("raw-pusher send markdown msg error, %s", err)
 		pushErr = multierror.Append(pushErr, err)
 	}
 

--- a/ctrl/ctrl.go
+++ b/ctrl/ctrl.go
@@ -13,17 +13,19 @@ import (
 	entSql "entgo.io/ent/dialect/sql"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/google/go-github/v53/github"
+	"github.com/hashicorp/go-multierror"
 	"github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/kataras/golog"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+	"modernc.org/sqlite"
+
 	"github.com/zema1/watchvuln/ent"
 	"github.com/zema1/watchvuln/ent/migrate"
 	"github.com/zema1/watchvuln/ent/vulninformation"
 	"github.com/zema1/watchvuln/grab"
 	"github.com/zema1/watchvuln/push"
-	"golang.org/x/sync/errgroup"
-	"modernc.org/sqlite"
 )
 
 func init() {
@@ -204,11 +206,6 @@ func (w *WatchVulnApp) Run(ctx context.Context) error {
 							continue
 						}
 					}
-					_, err = dbVuln.Update().SetPushed(true).Save(ctx)
-					if err != nil {
-						w.log.Errorf("failed to save pushed %s status, %s", v.UniqueKey, err)
-						continue
-					}
 
 					// find cve pr in nuclei repo
 					if v.CVE != "" && !w.config.NoGithubSearch {
@@ -226,13 +223,14 @@ func (w *WatchVulnApp) Run(ctx context.Context) error {
 						}
 					}
 					w.log.Infof("Pushing %s", v)
-					err = w.textPusher.PushMarkdown(v.Title, push.RenderVulnInfo(v))
-					if err != nil {
-						w.log.Errorf("text-pusher send dingding msg error, %s", err)
-					}
-					err = w.rawPusher.PushRaw(push.NewRawVulnInfoMessage(v))
-					if err != nil {
-						w.log.Errorf("raw-pusher send dingding msg error, %s", err)
+					if err := w.pushVuln(v); err == nil {
+						// 如果两种推送都成功，才标记为已推送
+						_, err = dbVuln.Update().SetPushed(true).Save(ctx)
+						if err != nil {
+							w.log.Errorf("failed to save pushed %s status, %s", v.UniqueKey, err)
+						}
+					} else {
+						w.log.Errorf("failed to push %s, %s", v.UniqueKey, err)
 					}
 				} else {
 					w.log.Infof("skipped %s as not valuable", v)
@@ -240,6 +238,22 @@ func (w *WatchVulnApp) Run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+func (w *WatchVulnApp) pushVuln(vul *grab.VulnInfo) error {
+	var pushErr *multierror.Error
+
+	if err := w.textPusher.PushMarkdown(vul.Title, push.RenderVulnInfo(vul)); err != nil {
+		w.log.Errorf("text-pusher send markdown msg error, %s", err)
+		pushErr = multierror.Append(pushErr, err)
+	}
+
+	if err := w.rawPusher.PushRaw(push.NewRawVulnInfoMessage(vul)); err != nil {
+		w.log.Errorf("raw-pusher send markdown msg error, %s", err)
+		pushErr = multierror.Append(pushErr, err)
+	}
+
+	return pushErr.ErrorOrNil()
 }
 
 func (w *WatchVulnApp) Close() {


### PR DESCRIPTION
部分 IM 有信息推送最大数量限制，eg 钉钉每分钟 20 条。

如果一次需要推送的漏洞数量超过最大数限制，则此消息会在未推送成功的情况下被标记为已推送。

其他意外情况如网络异常导致推送失败时也会被标记为已推送。