### PR TITLE
feat: Add support for Telegram push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Docker 方式推荐使用环境变量来配置服务参数
 | `SERVERCHAN_KEY `       | Server酱的 `SCKEY`                                                        |                                         |
 | `WEBHOOK_URL`           | 自定义 webhook 服务的完整 url                                                   |                                         |
 | `BARK_URL`              | Bark 服务的完整 url, 路径需要包含 DeviceKey                                        |                                         |
+| `TELEGRAM_BOT_TOKEN`    | Telegram Bot Token                                                      |                                         |
+| `TELEGRAM_CHAT_IDS`     | Telegram Bot 需要发送给的 chat 列表，使用 `,` 分割                                   |                                         |
 | `SOURCES`               | 启用哪些漏洞信息源，逗号分隔, 可选 `avd`, `ti`, `oscs`, `seebug`,`threatbook`,`struts2` | `avd,ti,oscs,threatbook,seebug,struts2` |
 | `INTERVAL`              | 检查周期，支持秒 `60s`, 分钟 `10m`, 小时 `1h`, 最低 `1m`                              | `30m`                                   |
 | `ENABLE_CVE_FILTER`     | 启用 CVE 过滤，开启后多个数据源的统一 CVE 将只推送一次                                        | `true`                                  |
@@ -172,6 +174,8 @@ GLOBAL OPTIONS:
    --lark-access-token value, --lt value      webhook access token of lark
    --lark-sign-secret value, --ls value       sign secret of lark
    --serverchan-key value, --sk value         send key for server chan
+   --telegram-bot-token value, --tgtk value   telegram bot token, ex: 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
+   --telegram-chat-ids value, --tgids value   chat ids want to send on telegram, ex: 123456,4312341,123123
    --webhook-url value, --webhook value       your webhook server url, ex: http://127.0.0.1:1111/webhook
    --wechatwork-key value, --wk value         webhook key of wechat work
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 	github.com/dop251/goja v0.0.0-20231027120936-b396bb4c349d
 	github.com/dop251/goja_nodejs v0.0.0-20231122114759-e84d9a924c5c
 	github.com/go-sql-driver/mysql v1.7.1
+	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
 	github.com/google/go-github/v53 v53.2.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/imroc/req/v3 v3.42.2
 	github.com/jackc/pgx/v5 v5.5.1
 	github.com/kataras/golog v0.1.8
@@ -46,7 +48,6 @@ require (
 	github.com/google/pprof v0.0.0-20231212022811-ec68065c825e // indirect
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl/v2 v2.16.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
@@ -68,6 +69,7 @@ require (
 	github.com/refraction-networking/utls v1.6.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20231213231151-1d8dd44e695e // indirect
 	github.com/zclconf/go-cty v1.13.1 // indirect
 	go.uber.org/mock v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrt
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
+github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible h1:2cauKuaELYAEARXRkq2LrJ0yDDv1rW7+wrTEdVL3uaU=
+github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible/go.mod h1:qf9acutJ8cwBUhm1bqgz6Bei9/C/c93FPDljKWwsOgM=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -158,6 +160,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/technoweenie/multipartstreamer v1.0.1 h1:XRztA5MXiR1TIRHxH2uNxXxaIkKQDeX7m2XsSOlQEnM=
+github.com/technoweenie/multipartstreamer v1.0.1/go.mod h1:jNVxdtShOxzAsukZwTSw6MDx5eUJoiEBsSvzDU9uzog=
 github.com/urfave/cli/v2 v2.26.0 h1:3f3AMg3HpThFNT4I++TKOejZO8yU55t3JnnSr4S4QEI=
 github.com/urfave/cli/v2 v2.26.0/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
 github.com/vimsucks/wxwork-bot-go v0.0.0-20221213061339-fcbcd88ede1c h1:gyl9LgDfFBpVSbAY816tU/nhDuSHMa0tXoleQrIJyE8=

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kataras/golog"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
+
 	"github.com/zema1/watchvuln/push"
 )
 
@@ -86,6 +87,18 @@ func main() {
 			Name:     "bark-url",
 			Aliases:  []string{"bark"},
 			Usage:    "your bark server url, ex: http://127.0.0.1:1111/DeviceKey",
+			Category: "[\x00Push Options]",
+		},
+		&cli.StringFlag{
+			Name:     "telegram-bot-token",
+			Aliases:  []string{"tgtk"},
+			Usage:    "your telegram bot token, ex: 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+			Category: "[\x00Push Options]",
+		},
+		&cli.StringFlag{
+			Name:     "telegram-chat-ids",
+			Aliases:  []string{"tgids"},
+			Usage:    "your chat ids want to send on telegram, ex: 123456,4312341,123123",
 			Category: "[\x00Push Options]",
 		},
 		&cli.StringFlag{
@@ -256,6 +269,8 @@ func initPusher(c *cli.Context) (push.TextPusher, push.RawPusher, error) {
 	larkToken := c.String("lark-access-token")
 	larkSecret := c.String("lark-sign-secret")
 	serverChanKey := c.String("serverchan-key")
+	telegramBotTokey := c.String("telegram-bot-token")
+	telegramChatIDs := c.String("telegram-chat-ids")
 
 	if os.Getenv("DINGDING_ACCESS_TOKEN") != "" {
 		dingToken = os.Getenv("DINGDING_ACCESS_TOKEN")
@@ -281,6 +296,13 @@ func initPusher(c *cli.Context) (push.TextPusher, push.RawPusher, error) {
 	if os.Getenv("SERVERCHAN_KEY") != "" {
 		serverChanKey = os.Getenv("SERVERCHAN_KEY")
 	}
+	if os.Getenv("TELEGRAM_BOT_TOKEN") != "" {
+		telegramBotTokey = os.Getenv("TELEGRAM_BOT_TOKEN")
+	}
+	if os.Getenv("TELEGRAM_CHAT_IDS") != "" {
+		telegramChatIDs = os.Getenv("TELEGRAM_CHAT_IDS")
+	}
+
 	var textPusher []push.TextPusher
 	var rawPusher []push.RawPusher
 	if dingToken != "" && dingSecret != "" {
@@ -303,6 +325,13 @@ func initPusher(c *cli.Context) (push.TextPusher, push.RawPusher, error) {
 	}
 	if serverChanKey != "" {
 		textPusher = append(textPusher, push.NewServerChan(serverChanKey))
+	}
+	if telegramBotTokey != "" && telegramChatIDs != "" {
+		tgPusher, err := push.NewTelegram(telegramBotTokey, telegramChatIDs)
+		if err != nil {
+			return nil, nil, fmt.Errorf("init telegram error %w", err)
+		}
+		textPusher = append(textPusher, tgPusher)
 	}
 	if len(textPusher) == 0 && len(rawPusher) == 0 {
 		msg := `

--- a/main.go
+++ b/main.go
@@ -92,13 +92,13 @@ func main() {
 		&cli.StringFlag{
 			Name:     "telegram-bot-token",
 			Aliases:  []string{"tgtk"},
-			Usage:    "your telegram bot token, ex: 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+			Usage:    "telegram bot token, ex: 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
 			Category: "[\x00Push Options]",
 		},
 		&cli.StringFlag{
 			Name:     "telegram-chat-ids",
 			Aliases:  []string{"tgids"},
-			Usage:    "your chat ids want to send on telegram, ex: 123456,4312341,123123",
+			Usage:    "chat ids want to send on telegram, ex: 123456,4312341,123123",
 			Category: "[\x00Push Options]",
 		},
 		&cli.StringFlag{

--- a/push/telegram.go
+++ b/push/telegram.go
@@ -1,0 +1,89 @@
+package push
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/kataras/golog"
+)
+
+var _ = TextPusher(&Telegram{})
+
+type Telegram struct {
+	APIToken string
+	log      *golog.Logger
+	client   *tgbotapi.BotAPI
+	chatIDs  []int64
+}
+
+// NewTelegram creates a new Telegram pusher, it requires a token and a list of chatIDs
+// separated by comma. eg "123456,4312341,123123"
+func NewTelegram(token string, chatIDs string) (*Telegram, error) {
+	bot, err := tgbotapi.NewBotAPI(token)
+	if err != nil {
+		return nil, fmt.Errorf("NewTelegram NewBotAPI failed: %w", err)
+	}
+	ids, err := convertChatIDs(chatIDs)
+	if err != nil {
+		return nil, fmt.Errorf("NewTelegram convertChatIDs failed: %w", err)
+	}
+	return &Telegram{
+		APIToken: token,
+		log:      golog.Child("[telegram]"),
+		client:   bot,
+		chatIDs:  ids,
+	}, nil
+}
+
+func convertChatIDs(rawIDs string) ([]int64, error) {
+	ids := strings.Split(rawIDs, ",")
+	var chatIDs []int64
+	for _, id := range ids {
+		chatID := strings.TrimSpace(id)
+		if chatID == "" {
+			continue
+		}
+		// convert string to int64
+		id64, err := strconv.ParseInt(chatID, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert chatID %q to int64: %w", id, err)
+		}
+		chatIDs = append(chatIDs, id64)
+	}
+	if len(chatIDs) == 0 {
+		return nil, fmt.Errorf("no valid chatIDs found")
+	}
+	return chatIDs, nil
+}
+
+func (t *Telegram) PushText(content string) error {
+	msg := tgbotapi.NewMessage(0, content)
+	msg.ParseMode = tgbotapi.ModeHTML
+
+	for _, chatID := range t.chatIDs {
+		msg.ChatID = chatID
+		_, err := t.client.Send(msg)
+		if err != nil {
+			return fmt.Errorf("failed to send message to Telegram chat %q err %w", chatID, err)
+		}
+	}
+	return nil
+}
+
+func (t *Telegram) PushMarkdown(title, content string) error {
+	fullMessage := title + "\n" + content // Treating subject as message title
+
+	msg := tgbotapi.NewMessage(0, fullMessage)
+	msg.ParseMode = tgbotapi.ModeMarkdown
+
+	for _, chatID := range t.chatIDs {
+		msg.ChatID = chatID
+		_, err := t.client.Send(msg)
+		if err != nil {
+			return fmt.Errorf("failed to send message to Telegram chat %q err %w", chatID, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
添加了针对 telegram 的推送支持和命令行推送选项，Close #62 

```go
func TestNewTelegram(t *testing.T) {
	tg, err := NewTelegram("123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11", "123456,4312341,123123")
	if err != nil {
		t.Fatal(err)
	}
	err = tg.PushMarkdown("markdown test", "test")
	if err != nil {
		t.Errorf("push markdown failed: %v", err)
	}
}
```
