### PR TITLE
fix: get latest kev vulns after sort

### DIFF
--- a/grab/kev.go
+++ b/grab/kev.go
@@ -64,9 +64,9 @@ func (c *KEVCrawler) GetUpdate(ctx context.Context, pageLimit int) ([]*VulnInfo,
 	sort.Slice(result.Vulnerabilities, func(i, j int) bool {
 		return result.Vulnerabilities[i].DateAdded > result.Vulnerabilities[j].DateAdded
 	})
-	for i := 1; i <= itemLimit; i++ {
+	for i := 0; i < itemLimit; i++ {
 		var vulnInfo VulnInfo
-		vuln := result.Vulnerabilities[maxCount-i]
+		vuln := result.Vulnerabilities[i] //排序后正向取漏洞
 		vulnInfo.UniqueKey = vuln.CveID + "_KEV"
 		vulnInfo.Title = vuln.VulnerabilityName
 		vulnInfo.Description = vuln.ShortDescription

--- a/grab/kev.go
+++ b/grab/kev.go
@@ -75,6 +75,7 @@ func (c *KEVCrawler) GetUpdate(ctx context.Context, pageLimit int) ([]*VulnInfo,
 		vulnInfo.Solutions = vuln.RequiredAction
 		vulnInfo.Disclosure = vuln.DateAdded
 		vulnInfo.From = "https://www.cisa.gov/known-exploited-vulnerabilities-catalog"
+		vulnInfo.References = append(vulnInfo.References, vuln.Notes)
 		vulnInfo.Tags = []string{vuln.VendorProject, vuln.Product, "在野利用"}
 		vulnInfo.Creator = c
 		vulnInfos = append(vulnInfos, &vulnInfo)

--- a/grab/kev_test.go
+++ b/grab/kev_test.go
@@ -25,6 +25,7 @@ func TestKEV(t *testing.T) {
 		assert.NotEmpty(v.Title)
 		assert.NotEmpty(v.Disclosure)
 		assert.NotEmpty(v.Severity)
+		assert.NotEmpty(v.References)
 
 	}
 	assert.Equal(count, 50)


### PR DESCRIPTION
1.排序后正向取kev漏洞，保证获取到的是最新漏洞
2.kev漏洞添加references字段